### PR TITLE
Attempt to remove setup.py with PEP 660 in setuptools 64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Install Plugin
         run: |
           pip install -e .
+          pip install --no-deps -U git+https://github.com/pytroll/satpy.git
 
       - name: Run linting
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ packages = ["satpy_cpe"]
 example_composites = "satpy_cpe"
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=64.0.3", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-# Workaround until https://github.com/pypa/setuptools/issues/2816 is resolved
-from setuptools import setup
-setup()


### PR DESCRIPTION
PEP 660 (no need for a setup.py) is now supported in setuptools 64.0+ the minimal setup.py should no longer be needed.